### PR TITLE
fix: qt6.2.4 lib was ported

### DIFF
--- a/examples/examples-common.pri
+++ b/examples/examples-common.pri
@@ -1,5 +1,6 @@
 QT       += core network sql xml
 QT       += gui
+QT       += core5compat
 CONFIG   += console
 CONFIG   -= app_bundle
 TEMPLATE = app

--- a/examples/gdrivebash/GdriveCommands.cpp
+++ b/examples/gdrivebash/GdriveCommands.cpp
@@ -332,7 +332,7 @@ void GdriveCommands::clean_space_content(QString spaceName)
 void GdriveCommands::rm_appdata_files(QString name_exceptId)
 {
     QStringList arg_list = name_exceptId.split(" ",
-                                               QString::SkipEmptyParts);
+                                               Qt::SkipEmptyParts);
     if(arg_list.size() == 0)
         {
             std::cout << "Invalid parameters, expected <fileName> <fileId> (to skip)" << std::endl;
@@ -367,7 +367,7 @@ void GdriveCommands::rm_appdata_files(QString name_exceptId)
 void GdriveCommands::find_by_name(QString name_space_parentId)
 {
     QStringList arg_list = name_space_parentId.split(" ",
-                                                     QString::SkipEmptyParts);
+                                                     Qt::SkipEmptyParts);
     QString name;
     QString parentId;
 
@@ -474,7 +474,7 @@ void GdriveCommands::get(QString fileId)
 void GdriveCommands::rename(QString fileId_space_new_title) 
 {
     QStringList arg_list = fileId_space_new_title.split(" ",
-                                                        QString::SkipEmptyParts);
+                                                        Qt::SkipEmptyParts);
     if (arg_list.size() < 2)
         {
             std::cout << "Invalid parameters, expected <fileID> <fileName>" << std::endl;
@@ -503,7 +503,7 @@ void GdriveCommands::change_mime(QString fileId_space_new_mimeType)
     std::cout << "Google doesn't do it (Jan/2017) - you have to upload file again" << std::endl;
     
     QStringList arg_list = fileId_space_new_mimeType.split(" ",
-                                                           QString::SkipEmptyParts);
+                                                           Qt::SkipEmptyParts);
     if (arg_list.size() < 2)
         {
             std::cout << "Invalid parameters, expected <fileID> <mimeType>" << std::endl;
@@ -766,7 +766,7 @@ void GdriveCommands::upload_simple(QString fileName)
 void GdriveCommands::upgrade_file(QString localFile_parentFolderId)
 {
     QStringList arg_list = localFile_parentFolderId.split(" ",
-                                                          QString::SkipEmptyParts);
+                                                          Qt::SkipEmptyParts);
     if (arg_list.isEmpty())
         {
             std::cout << "<fileName> required(local-path), optional <parentId>" << std::endl;
@@ -797,7 +797,7 @@ void GdriveCommands::upgrade_file(QString localFile_parentFolderId)
 void GdriveCommands::create_using_id(QString fileName_space_fileId)
 {
     QStringList arg_list = fileName_space_fileId.split(" ",
-        QString::SkipEmptyParts);
+        Qt::SkipEmptyParts);
     if (arg_list.size() != 2)
     {
         std::cout << "<fileName> required(local-path) <fileId>" << std::endl;
@@ -830,7 +830,7 @@ void GdriveCommands::rm(QString arg)
         }
 
     QStringList arg_list = arg.split(" ",
-                                     QString::SkipEmptyParts);
+                                     Qt::SkipEmptyParts);
     
     try
         {
@@ -851,7 +851,7 @@ void GdriveCommands::rm(QString arg)
 void GdriveCommands::mkdir(QString title_Space_parentFolderId)
 {
     QStringList arg_list = title_Space_parentFolderId.split(" ",
-                                                            QString::SkipEmptyParts);
+                                                            Qt::SkipEmptyParts);
     if(arg_list.size() < 1)
         {
             std::cout << "Invalid parameters, expected <title> <parent_id>" << std::endl;
@@ -922,7 +922,7 @@ void GdriveCommands::ls_comments(QString fileId)
 void GdriveCommands::rm_comment(QString fileId_Space_commentId)
 {
     QStringList arg_list = fileId_Space_commentId.split(" ",
-                                                        QString::SkipEmptyParts);
+                                                        Qt::SkipEmptyParts);
     if(arg_list.size() < 2)
         {
             std::cout << "Invalid parameters, expected <file_id> <comment_id>" << std::endl;
@@ -946,7 +946,7 @@ void GdriveCommands::rm_comment(QString fileId_Space_commentId)
 void GdriveCommands::get_comment(QString fileId_Space_commentId)
 {
     QStringList arg_list = fileId_Space_commentId.split(" ",
-                                                        QString::SkipEmptyParts);
+                                                        Qt::SkipEmptyParts);
     if(arg_list.size() < 2)
         {
             std::cout << "Invalid parameters, expected <file_id> <comment_id>" << std::endl;
@@ -1021,7 +1021,7 @@ void GdriveCommands::ls_permissions(QString fileId)
 void GdriveCommands::get_permission(QString fileId_Space_permissionId)
 {
     QStringList arg_list = fileId_Space_permissionId.split(" ",
-                                                           QString::SkipEmptyParts);
+                                                           Qt::SkipEmptyParts);
     if(arg_list.size() < 2)
         {
             std::cout << "Invalid parameters, expected <file_id> <comment_id>" << std::endl;
@@ -1070,7 +1070,7 @@ void GdriveCommands::create_permissions(QString fileId)
 void GdriveCommands::delete_permissions(QString fileId_Space_permissionId)
 {
     QStringList arg_list = fileId_Space_permissionId.split(" ",
-        QString::SkipEmptyParts);
+        Qt::SkipEmptyParts);
     if (arg_list.size() < 2)
     {
         std::cout << "Invalid parameters, expected <file_id> <permission_id>" << std::endl;
@@ -1121,7 +1121,7 @@ void GdriveCommands::ls_revisions(QString fileId)
 void GdriveCommands::get_revision(QString fileId_Space_revisionId)
 {
     QStringList arg_list = fileId_Space_revisionId.split(" ",
-        QString::SkipEmptyParts);
+        Qt::SkipEmptyParts);
     if (arg_list.size() < 2)
     {
         std::cout << "Invalid parameters, expected <file_id> <revision_id>" << std::endl;

--- a/examples/gmailbash/GmailCommands.cpp
+++ b/examples/gmailbash/GmailCommands.cpp
@@ -207,7 +207,7 @@ void GmailCommands::send_prepared_rfc822(QString messageFileName)
 void GmailCommands::send_as_html(QString to_subject_text)
 {
     QStringList arg_list = to_subject_text.split(" ",
-                                                 QString::SkipEmptyParts);
+                                                 Qt::SkipEmptyParts);
 
     if (arg_list.size() < 3)
         {
@@ -235,7 +235,7 @@ void GmailCommands::send_as_html(QString to_subject_text)
 void GmailCommands::send_att(QString to_subject_text)
 {
     QStringList arg_list = to_subject_text.split(" ",
-                                                 QString::SkipEmptyParts);
+                                                 Qt::SkipEmptyParts);
 
     if (arg_list.size() < 3)
         {
@@ -336,7 +336,7 @@ void GmailCommands::delete_msg(QString message_id)
 void GmailCommands::add_label(QString message_id_label)
 {
     QStringList arg_list = message_id_label.split(" ",
-                                                  QString::SkipEmptyParts);
+                                                  Qt::SkipEmptyParts);
 
     if (arg_list.size() < 2)
         {
@@ -365,7 +365,7 @@ void GmailCommands::add_label(QString message_id_label)
 void GmailCommands::remove_label(QString message_id_label)
 {
     QStringList arg_list = message_id_label.split(" ",
-                                                  QString::SkipEmptyParts);
+                                                  Qt::SkipEmptyParts);
 
     if (arg_list.size() < 2)
         {
@@ -646,7 +646,7 @@ void GmailCommands::save_raw(QString msg_id)
 void GmailCommands::get_html(QString message_id_space_fileName)
 {
     QStringList arg_list = message_id_space_fileName.split(" ",
-                                                           QString::SkipEmptyParts);
+                                                           Qt::SkipEmptyParts);
     if(arg_list.size() < 2)
         {
             std::cout << "Invalid parameters, expected <message_id> <file_name>" << std::endl;
@@ -765,7 +765,7 @@ void GmailCommands::delete_label(QString label_id)
 
 void GmailCommands::update_label(QString labelid_space_name)
 {
-    QStringList arg_list = labelid_space_name.split(" ", QString::SkipEmptyParts);
+    QStringList arg_list = labelid_space_name.split(" ", Qt::SkipEmptyParts);
     if(arg_list.size() < 2)
         {
             std::cout << "Invalid parameters, expected <label_id> <new_name>" << std::endl;

--- a/prj/googleQt.pro
+++ b/prj/googleQt.pro
@@ -1,5 +1,6 @@
 QT       += network xml sql
 QT       += gui
+QT       += core5compat
 CONFIG += staticlib
 CONFIG -= flat
 TEMPLATE = lib

--- a/src/gmail/GmailCache.cpp
+++ b/src/gmail/GmailCache.cpp
@@ -4,6 +4,7 @@
 #include <ctime>
 #include <QDir>
 #include <QTextDocument>
+#include <QRegExp>
 #include "Endpoint.h"
 #include "GmailCacheRoutes.h"
 #include "gcontact/GcontactCache.h"
@@ -968,7 +969,8 @@ void mail_cache::GMailCacheQueryTask::fetchMessage(messages::MessageResource* m)
                         QByteArray payload_body = QByteArray::fromBase64(p.body().data(), QByteArray::Base64UrlEncoding);
                         html_text = payload_body.constData();
                         plain_text = html_text;
-                        plain_text.remove(QRegExp("<[^>]*>"));
+                        QRegExp exp("<[^>]*>");
+                        plain_text = exp.removeIn(plain_text);
                     }
                 else
                     {
@@ -977,7 +979,8 @@ void mail_cache::GMailCacheQueryTask::fetchMessage(messages::MessageResource* m)
                         if (pres.html_text_loaded) {
                             if (!pres.plain_text_loaded) {
                                 plain_text = html_text;
-                                plain_text.remove(QRegExp("<[^>]*>"));
+                                QRegExp exp("<[^>]*>");
+                                plain_text = exp.removeIn(plain_text);
                                 pres.plain_text_loaded = true;
                             }
                         }
@@ -996,7 +999,8 @@ void mail_cache::GMailCacheQueryTask::fetchMessage(messages::MessageResource* m)
                                 if (pres.html_text_loaded) {
                                     if (!pres.plain_text_loaded) {
                                         plain_text = html_text;
-                                        plain_text.remove(QRegExp("<[^>]*>"));
+                                        QRegExp exp("<[^>]*>");
+                                        plain_text = exp.removeIn(plain_text);
                                         pres.plain_text_loaded = true;
                                     }
                                 }
@@ -3692,7 +3696,7 @@ void mail_cache::GThreadsStorage::bindSQL(QSqlQuery* q, CACHE_LIST<ThreadData>& 
         history_id << t->m_history_id;
         messages_count << t->m_messages_count;
         snippet << t->m_snippet;
-        filter_mask << t->m_filter_mask;
+        filter_mask << static_cast<qulonglong>(t->m_filter_mask);
         internalDate << t->internalDate();
         id << t->m_id;
 
@@ -3727,7 +3731,7 @@ void mail_cache::GThreadsStorage::bind_filterSQL(QSqlQuery* q, CACHE_LIST<Thread
             continue;
         }
 
-        filter_mask << t->m_filter_mask;
+        filter_mask << static_cast<qulonglong>(t->m_filter_mask);
         id << t->m_id;
     }
     q->addBindValue(filter_mask);
@@ -3753,7 +3757,7 @@ void mail_cache::GThreadsStorage::bind_prefilterSQL(QSqlQuery* q, CACHE_LIST<Thr
             continue;
         }
 
-        fmask << t->m_prefilter_mask;
+        fmask << static_cast<qulonglong>(t->m_prefilter_mask);
         id << t->m_id;
     }
     q->addBindValue(fmask);
@@ -3765,8 +3769,8 @@ bool mail_cache::GThreadsStorage::execOutOfBatchSQL(QSqlQuery* q, mail_cache::Th
     q->addBindValue(t->m_history_id);
     q->addBindValue(t->m_messages_count);
     q->addBindValue(t->m_snippet);
-    q->addBindValue(t->m_filter_mask);
-    q->addBindValue(t->internalDate());
+    q->addBindValue(static_cast<qulonglong>(t->m_filter_mask));
+    q->addBindValue(static_cast<qulonglong>(t->internalDate()));
     q->addBindValue(t->m_id);
     return q->exec();
 };

--- a/src/gmail/GmailRequestArg.cpp
+++ b/src/gmail/GmailRequestArg.cpp
@@ -243,14 +243,14 @@ void MimeBodyPart::setContent(QString content, QString _type)
 QByteArray MimeBodyPart::toRfc822()const
 {
     QByteArray rv = QString("Content-Type: %1\r\n").arg(m_content_type).toStdString().c_str();
-    rv += QString("Content-Transfer-Encoding: base64\r\n");
+    rv += QString("Content-Transfer-Encoding: base64\r\n").toStdString().c_str();
     switch(m_part_type)
         {
         case ptypePlain:
         case ptypeHtml: 
             {       
                 QByteArray ba(m_content.toStdString().c_str());
-                rv += QString("%1\r\n").arg(ba.toBase64(QByteArray::Base64Encoding).constData());
+                rv += QString("%1\r\n").arg(ba.toBase64(QByteArray::Base64Encoding).constData()).toStdString().c_str();
             }break;
         case ptypeNone:break;
         case ptypeFile: 
@@ -266,16 +266,16 @@ QByteArray MimeBodyPart::toRfc822()const
                     auto x_attachment_id = QString("f_%1").arg(qHash(m_content), 0, 16);
                     auto content_id = QString("<%1>").arg(x_attachment_id);
                     /*
-                    rv += QString("Content-ID: %1\r\n").arg(content_id);
+                    rv += QString("Content-ID: %1\r\n").arg(content_id).toStdString().c_str();
                     */
-                    rv += QString("X-Attachment-Id: %1\r\n").arg(x_attachment_id);
+                    rv += QString("X-Attachment-Id: %1\r\n").arg(x_attachment_id).toStdString().c_str();
 
                     QFileInfo fi(m_content);
                     QString file_name = fi.fileName();
-                    rv += QString("Content-Disposition: attachment; filename=%1\r\n\r\n").arg(file_name);
+                    rv += QString("Content-Disposition: attachment; filename=%1\r\n\r\n").arg(file_name).toStdString().c_str();
 
                     QByteArray ba = mf.readAll().toBase64(QByteArray::Base64Encoding);
-                    rv += QString("%1\r\n").arg(ba.constData());
+                    rv += QString("%1\r\n").arg(ba.constData()).toStdString().c_str();
                 }       
             }break;
         }
@@ -346,28 +346,28 @@ QByteArray SendMimeMessageArg::toRfc822()const
 
     QByteArray rv;
     rv =  QString("From: %1\r\n").arg(m_From).toStdString().c_str();
-    rv += QString("To: %1\r\n").arg(m_To);
-    rv += QString("Subject: %1\r\n").arg(m_Subject);
+    rv += QString("To: %1\r\n").arg(m_To).toStdString().c_str();
+    rv += QString("Subject: %1\r\n").arg(m_Subject).toStdString().c_str();
     QString ref_str = m_references;
     if (!m_InReplyToMsgId.isEmpty()) {
-        rv += QString("In-Reply-To: <%1@mail.gmail.com>\r\n").arg(m_InReplyToMsgId);
+        rv += QString("In-Reply-To: <%1@mail.gmail.com>\r\n").arg(m_InReplyToMsgId).toStdString().c_str();
         ref_str += QString("<%1@mail.gmail.com>").arg(m_InReplyToMsgId);
     }
     
     if (!ref_str.isEmpty()) {
-        rv += QString("References: %1\r\n").arg(ref_str);
+        rv += QString("References: %1\r\n").arg(ref_str).toStdString().c_str();
     }
-    rv += QString("MIME-Version: 1.0\r\n");
-    rv += QString("Content-Type: multipart/mixed; boundary=\"%1\"\r\n\r\n").arg(boundary);
+    rv += QString("MIME-Version: 1.0\r\n").toStdString().c_str();
+    rv += QString("Content-Type: multipart/mixed; boundary=\"%1\"\r\n\r\n").arg(boundary).toStdString().c_str();
     //rv += QString("Content-Type: multipart/alternative; boundary=\"%1\"\r\n\r\n").arg(boundary);
     for (auto& p : m_body_parts)
         {
-            rv += QString("--%1\r\n").arg(boundary);
+            rv += QString("--%1\r\n").arg(boundary).toStdString().c_str();
             QString part_content = p.toRfc822();
-            rv += part_content;
+            rv += part_content.toStdString().c_str();
         }
 
-    rv += QString("--%1--").arg(boundary);
+    rv += QString("--%1--").arg(boundary).toStdString().c_str();
 
     return rv;
 };

--- a/src/google/demo/ApiTerminal.h
+++ b/src/google/demo/ApiTerminal.h
@@ -71,7 +71,7 @@ Terminal(QString prompt):m_prompt(prompt){};
                             str_cmd = m_last_cmd;
                         }
                                                    
-                        QStringList arg_list = str_cmd.split(" ", QString::SkipEmptyParts);
+                        QStringList arg_list = str_cmd.split(" ", Qt::SkipEmptyParts);
                         if(!arg_list.empty()){
                             QString str = arg_list[0];
                             if(str.compare(exit_option.c_str(), Qt::CaseInsensitive) == 0)

--- a/src/google/endpoint/ApiBase.cpp
+++ b/src/google/endpoint/ApiBase.cpp
@@ -1,6 +1,7 @@
 #include <QFile>
 #include <QJsonParseError>
 #include <QNetworkInterface>
+#include <QRegExp>
 #include <functional>
 #include "ApiUtil.h"
 
@@ -55,7 +56,8 @@ bool googleQt::isConnectedToNetwork()
 
 QString googleQt::makeValidFileName(QString fileName) 
 {
-    QString rv = fileName.replace(QRegExp("[" + QRegExp::escape("\\/:*?\"<>|") + "]"), QString("_"));
+    QRegExp exp("[" + QRegExp::escape("\\/:*?\"<>|") + "]");
+    QString rv = exp.replaceIn(fileName, QString("_"));
     return rv;
 };
 
@@ -137,7 +139,7 @@ void QParamArg::ResponseFields2Builder(UrlBuilder& b)const
 
 STRING_LIST googleQt::split_string(QString s)
 {
-    QStringList s_list = s.split(" ", QString::SkipEmptyParts);
+    QStringList s_list = s.split(" ", Qt::SkipEmptyParts);
     STRING_LIST rv;
     for (QStringList::iterator i = s_list.begin(); i != s_list.end(); i++)
     {
@@ -164,7 +166,11 @@ QString googleQt::size_human(qreal num)
 
 QString googleQt::trim_alpha_label(QString lbl)
 {
-    QString rv = lbl.trimmed().toLower().remove(QRegExp("[^a-zA-Z\\d\\s]")).remove(QRegExp("\\s"));
+    QRegExp expFirst("[^a-zA-Z\\d\\s]");
+    QRegExp expSecond("\\s");
+    QString rv = lbl.trimmed().toLower();
+    rv = expFirst.removeIn(rv);
+    rv = expSecond.removeIn(rv);
     return rv;
 };
 


### PR DESCRIPTION
Hey! I wanted to use your library, but it doesn't build with Qt 6.2.4. I have corrected the code. Now she's going.

Attention! I didn't check the work! But the example utilities are launched (I did not check the performance).